### PR TITLE
perf: Executed is no longer used

### DIFF
--- a/contracts/proxies/LooksRareProxy.sol
+++ b/contracts/proxies/LooksRareProxy.sol
@@ -108,7 +108,7 @@ contract LooksRareProxy is IProxy, TokenRescuer, TokenTransferrer, SignatureChec
         address recipient,
         CollectionType collectionType,
         bool isAtomic
-    ) private returns (bool executed) {
+    ) private {
         if (isAtomic) {
             marketplace.matchAskWithTakerBidUsingETHAndWETH{value: takerBid.price}(takerBid, makerAsk);
             _transferTokenToRecipient(
@@ -118,7 +118,6 @@ contract LooksRareProxy is IProxy, TokenRescuer, TokenTransferrer, SignatureChec
                 makerAsk.tokenId,
                 makerAsk.amount
             );
-            executed = true;
         } else {
             try marketplace.matchAskWithTakerBidUsingETHAndWETH{value: takerBid.price}(takerBid, makerAsk) {
                 _transferTokenToRecipient(
@@ -128,7 +127,6 @@ contract LooksRareProxy is IProxy, TokenRescuer, TokenTransferrer, SignatureChec
                     makerAsk.tokenId,
                     makerAsk.amount
                 );
-                executed = true;
             } catch {}
         }
     }


### PR DESCRIPTION
Squeezing more juice

```
testBuyFromGemSwap() (gas: 0 (0.000%))
testBuyFromGemSwapTwoNFTsEachMarketplace() (gas: 0 (0.000%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceAtomic() (gas: -4642 (-0.065%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceNonAtomic() (gas: -4666 (-0.065%))
testBuyFromLooksRareAggregatorAtomic() (gas: -4626 (-0.068%))
testBuyFromLooksRareAggregatorNonAtomic() (gas: -4638 (-0.069%))
Overall gas change: -18572 (-0.267%)
```