### PR TITLE
perf: Use currency variable and cache order fee

### DIFF
--- a/contracts/proxies/SeaportProxy.sol
+++ b/contracts/proxies/SeaportProxy.sol
@@ -209,13 +209,14 @@ contract SeaportProxy is IProxy, TokenRescuer {
                 )
             {
                 if (feeRecipient != address(0)) {
+                    uint256 orderFee = (price * feeBp) / 10000;
                     if (currency == lastOrderCurrency) {
-                        fee += (price * feeBp) / 10000;
+                        fee += orderFee;
                     } else {
                         if (fee > 0) _transferFee(fee, lastOrderCurrency, feeRecipient);
 
                         lastOrderCurrency = currency;
-                        fee = (price * feeBp) / 10000;
+                        fee = orderFee;
                     }
                 }
             } catch {}


### PR DESCRIPTION
```
testExecuteZeroOriginator() (gas: -6 (-0.000%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceAtomic() (gas: -18043 (-0.262%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceNonAtomic() (gas: -18037 (-0.263%))
testBuyFromLooksRareAggregatorAtomic() (gas: -18056 (-0.278%))
testBuyFromLooksRareAggregatorNonAtomic() (gas: -18047 (-0.279%))
testExecuteReentrancy() (gas: -18056 (-0.313%))
testExecuteThroughAggregatorTwoOrders() (gas: -18043 (-0.378%))
testExecuteThroughAggregatorSingleOrder() (gas: -18056 (-0.392%))
testExecuteOrdersLengthMismatch() (gas: -243 (-0.393%))
testExecuteThroughV0AggregatorTwoOrders() (gas: -18043 (-0.457%))
testExecuteThroughV0AggregatorSingleOrder() (gas: -18056 (-0.478%))
testExecuteZeroOrders() (gas: -241 (-0.545%))
Overall gas change: -162927 (-4.038%)
```