### PR TITLE
test: LooksRareProxy ERC1155 tests

### DIFF
--- a/test/foundry/LooksRareProxyERC1155.t.sol
+++ b/test/foundry/LooksRareProxyERC1155.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IERC1155} from "@looksrare/contracts-libs/contracts/interfaces/generic/IERC1155.sol";
+import {LooksRareProxy} from "../../contracts/proxies/LooksRareProxy.sol";
+import {LooksRareAggregator} from "../../contracts/LooksRareAggregator.sol";
+import {ILooksRareAggregator} from "../../contracts/interfaces/ILooksRareAggregator.sol";
+import {BasicOrder, TokenTransfer} from "../../contracts/libraries/OrderStructs.sol";
+import {TestHelpers} from "./TestHelpers.sol";
+import {TestParameters} from "./TestParameters.sol";
+import {LooksRareProxyTestHelpers} from "./LooksRareProxyTestHelpers.sol";
+
+/**
+ * @notice LooksRareProxy ERC1155 tests
+ */
+contract LooksRareProxyERC1155Test is TestParameters, TestHelpers, LooksRareProxyTestHelpers {
+    LooksRareAggregator private aggregator;
+    LooksRareProxy private looksRareProxy;
+
+    function setUp() public {
+        vm.createSelectFork(MAINNET_RPC_URL, 15_877_290);
+
+        aggregator = new LooksRareAggregator();
+        looksRareProxy = new LooksRareProxy(LOOKSRARE_V1, address(aggregator));
+        aggregator.addFunction(address(looksRareProxy), LooksRareProxy.execute.selector);
+
+        vm.deal(_buyer, 1 ether);
+
+        // Forking from mainnet and the deployed addresses might have balance
+        vm.deal(address(aggregator), 0);
+        vm.deal(address(looksRareProxy), 0);
+    }
+
+    function testExecuteAtomic() public asPrankedUser(_buyer) {
+        _testExecute(true);
+    }
+
+    function testExecuteNonAtomic() public asPrankedUser(_buyer) {
+        _testExecute(false);
+    }
+
+    function _testExecute(bool isAtomic) private {
+        ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
+        TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
+
+        aggregator.execute{value: tradeData[0].orders[0].price}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
+
+        assertEq(IERC1155(0x5150B29a431eCe5eB0e62085535b8aaC8df193bE).balanceOf(_buyer, 1), 1);
+        assertEq(_buyer.balance, 0.99 ether);
+    }
+
+    function _generateTradeData() private view returns (ILooksRareAggregator.TradeData[] memory tradeData) {
+        BasicOrder[] memory orders = new BasicOrder[](1);
+        orders[0] = validSlicesOrder();
+
+        bytes[] memory ordersExtraData = new bytes[](1);
+        ordersExtraData[0] = abi.encode(orders[0].price, 9800, 13678, LOOKSRARE_STRATEGY_FIXED_PRICE_V1B);
+
+        tradeData = new ILooksRareAggregator.TradeData[](1);
+        tradeData[0] = ILooksRareAggregator.TradeData({
+            proxy: address(looksRareProxy),
+            selector: LooksRareProxy.execute.selector,
+            value: orders[0].price,
+            maxFeeBp: 0,
+            orders: orders,
+            ordersExtraData: ordersExtraData,
+            extraData: ""
+        });
+    }
+}

--- a/test/foundry/LooksRareProxyTestHelpers.sol
+++ b/test/foundry/LooksRareProxyTestHelpers.sol
@@ -83,4 +83,23 @@ abstract contract LooksRareProxyTestHelpers {
         order
             .signature = hex"c0b72a9fc4068e489c0464b44c6e93ff28c24e30bb2ff1776d6afbc23d8235e75d4c996bf069c445133dcdc01dd1615fedfbb4a3e43fc539d5795215baf767101b";
     }
+
+    function validSlicesOrder() internal pure returns (BasicOrder memory order) {
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+
+        order.signer = 0x3A8713065e4DAa9603b91Ef35d6a8336eF7b26C6;
+        order.collection = 0x5150B29a431eCe5eB0e62085535b8aaC8df193bE;
+        order.collectionType = CollectionType.ERC1155;
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 1;
+        order.tokenIds = tokenIds;
+        order.amounts = amounts;
+        order.price = 0.01 ether;
+        order.currency = WETH;
+        order.startTime = 1667292639;
+        order.endTime = 1669888235;
+        order
+            .signature = hex"f5e65638475e7387b9cc84a8dc52963e02ae2bd25a5f4b6f35a285fbf3e41e7c2c080d2e2b8293db1a824b1528691838996429a2d3d6062ea50d253cc33829661c";
+    }
 }

--- a/test/foundry/TestParameters.sol
+++ b/test/foundry/TestParameters.sol
@@ -7,6 +7,7 @@ abstract contract TestParameters {
     address internal constant GEMSWAP = 0x83C8F28c26bF6aaca652Df1DbBE0e1b56F8baBa2;
     address internal constant LOOKSRARE_V1 = 0x59728544B08AB483533076417FbBB2fD0B17CE3a;
     address internal constant LOOKSRARE_STRATEGY_FIXED_PRICE = 0x56244Bb70CbD3EA9Dc8007399F61dFC065190031;
+    address internal constant LOOKSRARE_STRATEGY_FIXED_PRICE_V1B = 0x579af6FD30BF83a5Ac0D636bc619f98DBdeb930c;
     address internal constant MOODIE = 0x0F23939EE95350F26D9C1B818Ee0Cc1C8Fd2b99D;
     address internal constant SUDOSWAP = 0x2B2e8cDA09bBA9660dCA5cB6233787738Ad68329;
     address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;


### PR DESCRIPTION
Was running LCOV, turns out we are missing coverage for TokenTransferrer's transfer ERC1155 line.