### PR TITLE
perf: Memory should have been calldata

### DIFF
--- a/contracts/proxies/LooksRareProxy.sol
+++ b/contracts/proxies/LooksRareProxy.sol
@@ -62,7 +62,7 @@ contract LooksRareProxy is IProxy, TokenRescuer, TokenTransferrer, SignatureChec
         if (ordersLength == 0 || ordersLength != ordersExtraData.length) revert InvalidOrderLength();
 
         for (uint256 i; i < ordersLength; ) {
-            BasicOrder memory order = orders[i];
+            BasicOrder calldata order = orders[i];
 
             OrderExtraData memory orderExtraData = abi.decode(ordersExtraData[i], (OrderExtraData));
 


### PR DESCRIPTION
```
testExecuteAtomic() (gas: -1797 (-0.288%))
testExecuteNonAtomic() (gas: -1797 (-0.309%))
testExecuteAtomicFail() (gas: -1797 (-0.419%))
testExecutePartialSuccess() (gas: -1797 (-0.453%))
testExecuteRefundExtraPaid() (gas: -2879 (-0.516%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceAtomic() (gas: -42258 (-0.533%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceNonAtomic() (gas: -42258 (-0.536%))
testBuyFromLooksRareAggregatorAtomic() (gas: -40457 (-0.538%))
testBuyFromLooksRareAggregatorNonAtomic() (gas: -40457 (-0.541%))
testExecuteAtomicFail() (gas: -1960 (-0.548%))
testExecutePartialSuccess() (gas: -1960 (-0.602%))
testExecuteAtomic() (gas: -1797 (-0.633%))
testExecuteNonAtomic() (gas: -1797 (-0.634%))
testExecuteAtomic() (gas: -1797 (-0.716%))
testExecuteNonAtomic() (gas: -1797 (-0.716%))
testExecutePartialSuccess() (gas: -3598 (-0.846%))
testExecuteZeroOriginator() (gas: -40457 (-0.869%))
testExecuteThroughAggregatorSingleOrder() (gas: -40457 (-0.871%))
testExecuteThroughAggregatorTwoOrdersAtomic() (gas: -42258 (-0.872%))
testExecuteThroughAggregatorTwoOrdersNonAtomic() (gas: -42258 (-0.872%))
testExecuteThroughV0AggregatorTwoOrders() (gas: -42282 (-1.135%))
testExecuteThroughV0AggregatorSingleOrder() (gas: -40481 (-1.146%))
testExecuteAtomicFail() (gas: -1797 (-1.272%))
Overall gas change: -440193 (-15.863%)
```

How an 1 line change makes so much difference, thanks Code4rena 🙏 