### PR TITLE
perf: No need to set isOrderAsk to its default value

### DIFF
--- a/contracts/proxies/LooksRareProxy.sol
+++ b/contracts/proxies/LooksRareProxy.sol
@@ -89,7 +89,7 @@ contract LooksRareProxy is IProxy, TokenRescuer, TokenTransferrer, SignatureChec
 
             OrderTypes.TakerOrder memory takerBid;
             {
-                takerBid.isOrderAsk = false;
+                // No need to set isOrderAsk as its default value is false
                 takerBid.taker = address(this);
                 takerBid.price = order.price;
                 takerBid.tokenId = makerAsk.tokenId;


### PR DESCRIPTION
There are some gas savings with IR turned on