### PR TITLE
perf: TokenReceiver memory args to calldata

### DIFF
--- a/contracts/TokenReceiver.sol
+++ b/contracts/TokenReceiver.sol
@@ -16,7 +16,7 @@ abstract contract TokenReceiver {
         address,
         uint256,
         uint256,
-        bytes memory
+        bytes calldata
     ) external virtual returns (bytes4) {
         return this.onERC1155Received.selector;
     }
@@ -24,9 +24,9 @@ abstract contract TokenReceiver {
     function onERC1155BatchReceived(
         address,
         address,
-        uint256[] memory,
-        uint256[] memory,
-        bytes memory
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
     ) external virtual returns (bytes4) {
         return this.onERC1155BatchReceived.selector;
     }


### PR DESCRIPTION
```
testRescueERC1155() (gas: -326 (-0.025%))
testRescueERC1155NotOwner() (gas: -326 (-0.025%))
testExecuteAtomic() (gas: -326 (-0.116%))
testExecuteNonAtomic() (gas: -326 (-0.116%))
testExecuteAtomic() (gas: -326 (-0.131%))
testExecuteNonAtomic() (gas: -326 (-0.131%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceAtomic() (gas: -83737 (-1.065%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceNonAtomic() (gas: -83737 (-1.070%))
testBuyFromLooksRareAggregatorAtomic() (gas: -83737 (-1.122%))
testBuyFromLooksRareAggregatorNonAtomic() (gas: -83737 (-1.128%))
testExecuteReentrancy() (gas: -83737 (-1.189%))
testExecuteThroughAggregatorTwoOrdersAtomic() (gas: -83737 (-1.471%))
testExecuteThroughAggregatorTwoOrdersNonAtomic() (gas: -83737 (-1.477%))
testExecuteThroughAggregatorSingleOrder() (gas: -83737 (-1.521%))
testExecuteThroughAggregatorTwoOrdersAtomic() (gas: -83796 (-1.750%))
testExecuteThroughAggregatorTwoOrdersNonAtomic() (gas: -83796 (-1.750%))
testExecuteThroughV0AggregatorTwoOrders() (gas: -80725 (-1.759%))
testExecuteZeroOriginator() (gas: -83796 (-1.821%))
testExecuteThroughAggregatorSingleOrder() (gas: -83796 (-1.825%))
testExecuteThroughV0AggregatorSingleOrder() (gas: -80725 (-1.832%))
testExecuteThroughV0AggregatorTwoOrders() (gas: -80725 (-2.192%))
testExecuteThroughV0AggregatorSingleOrder() (gas: -80725 (-2.313%))
Overall gas change: -1329936 (-25.828%)
```