### PR TITLE
perf: Unchecked arithmetic in SeaportProxy

### DIFF
--- a/contracts/proxies/SeaportProxy.sol
+++ b/contracts/proxies/SeaportProxy.sol
@@ -250,7 +250,9 @@ contract SeaportProxy is IProxy, TokenRescuer {
 
         OfferItem[] memory offer = new OfferItem[](1);
         // Seaport enums start with NATIVE and ERC20 so plus 2
-        offer[0].itemType = ItemType(uint8(order.collectionType) + 2);
+        unchecked {
+            offer[0].itemType = ItemType(uint8(order.collectionType) + 2);
+        }
         offer[0].token = order.collection;
         offer[0].identifierOrCriteria = order.tokenIds[0];
         uint256 amount = order.amounts[0];


### PR DESCRIPTION
```
testExecuteNonAtomic() (gas: -96 (-0.017%))
testExecutePartialSuccess() (gas: -96 (-0.024%))
testExecuteAtomic() (gas: -165 (-0.026%))
testExecutePartialSuccess() (gas: -96 (-0.030%))
testExecuteWithExcessUSDCNonAtomic() (gas: -192 (-0.033%))
testExecuteNonAtomic() (gas: -192 (-0.034%))
testExecuteRefundFromSeaportProxyNonAtomic() (gas: -192 (-0.036%))
testExecuteAtomicFail() (gas: -165 (-0.039%))
testExecuteRefundFromLooksRareAggregatorNonAtomic() (gas: -192 (-0.039%))
testExecuteWithExcessUSDCAtomic() (gas: -261 (-0.040%))
testExecuteNonAtomic() (gas: -96 (-0.040%))
testExecuteAtomic() (gas: -261 (-0.041%))
testExecuteNonAtomic() (gas: -192 (-0.043%))
testExecuteAtomicFail() (gas: -165 (-0.046%))
testExecutePartialSuccess() (gas: -192 (-0.051%))
testExecuteRefundFromSeaportProxyNonAtomic() (gas: -192 (-0.052%))
testExecuteRefundFromLooksRareAggregatorNonAtomic() (gas: -192 (-0.054%))
testExecuteNonAtomic() (gas: -192 (-0.055%))
testExecuteWithFeesAtomic() (gas: -509 (-0.057%))
testExecuteWithFeesNonAtomic() (gas: -472 (-0.058%))
testExecuteRefundFromSeaportProxyAtomic() (gas: -330 (-0.060%))
testExecuteAtomic() (gas: -165 (-0.061%))
testExecuteRefundFromLooksRareAggregatorAtomic() (gas: -330 (-0.064%))
testExecutePartialSuccess() (gas: -192 (-0.066%))
testExecuteAtomic() (gas: -330 (-0.066%))
testExecuteMaxFeeBpViolationNonAtomic() (gas: -304 (-0.070%))
testExecuteWithFeesAtomic() (gas: -508 (-0.075%))
testExecuteMaxFeeBpViolationAtomic() (gas: -357 (-0.076%))
testExecuteRefundFromSeaportProxyAtomic() (gas: -330 (-0.082%))
testExecuteRefundFromLooksRareAggregatorAtomic() (gas: -330 (-0.084%))
testExecuteWithFeesNonAtomic() (gas: -540 (-0.084%))
testExecuteAtomic() (gas: -330 (-0.085%))
testExecuteUSDCETHAlternateNonAtomic() (gas: -944 (-0.089%))
testExecuteUSDCETHAlternateAtomic() (gas: -1018 (-0.089%))
testExecuteETHUSDCAlternateNonAtomic() (gas: -1012 (-0.095%))
testExecuteETHUSDCAlternateAtomic() (gas: -1086 (-0.095%))
testExecuteUSDCThenETHAtomic() (gas: -1154 (-0.102%))
testExecuteUSDCThenETHNonAtomic() (gas: -1080 (-0.103%))
testExecuteWithFeesNonAtomic() (gas: -608 (-0.107%))
testExecuteETHThenUSDCAtomic() (gas: -1222 (-0.108%))
testExecuteETHThenUSDCNonAtomic() (gas: -1148 (-0.109%))
testExecuteAtomicFail() (gas: -330 (-0.116%))
testExecuteWithFeesAtomic() (gas: -714 (-0.120%))
testExecuteAtomicFail() (gas: -330 (-0.180%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceAtomic() (gas: -29979 (-0.381%))
testBuyFromLooksRareAggregatorTwoNFTsEachMarketplaceNonAtomic() (gas: -29859 (-0.381%))
testBuyFromLooksRareAggregatorAtomic() (gas: -29832 (-0.400%))
testBuyFromLooksRareAggregatorNonAtomic() (gas: -29763 (-0.401%))
testExecuteReentrancy() (gas: -30051 (-0.427%))
testExecuteThroughAggregatorTwoOrdersNonAtomic() (gas: -29859 (-0.527%))
testExecuteThroughAggregatorTwoOrdersAtomic() (gas: -29997 (-0.527%))
testExecuteThroughAggregatorSingleOrder() (gas: -29832 (-0.542%))
testExecuteOrdersLengthMismatch() (gas: -408 (-0.573%))
testExecuteThroughV0AggregatorTwoOrders() (gas: -29979 (-0.653%))
testExecuteThroughV0AggregatorSingleOrder() (gas: -29832 (-0.677%))
testExecuteZeroOrders() (gas: -405 (-0.791%))
Overall gas change: -318598 (-9.284%)
```