### PR TITLE
chore: Unnecessary event

### DIFF
--- a/contracts/LooksRareAggregator.sol
+++ b/contracts/LooksRareAggregator.sol
@@ -119,7 +119,6 @@ contract LooksRareAggregator is
     function setERC20EnabledLooksRareAggregator(address _erc20EnabledLooksRareAggregator) external onlyOwner {
         if (erc20EnabledLooksRareAggregator != address(0)) revert AlreadySet();
         erc20EnabledLooksRareAggregator = _erc20EnabledLooksRareAggregator;
-        emit ERC20EnabledLooksRareAggregatorSet();
     }
 
     /**

--- a/contracts/interfaces/ILooksRareAggregator.sol
+++ b/contracts/interfaces/ILooksRareAggregator.sol
@@ -31,11 +31,6 @@ interface ILooksRareAggregator {
     ) external payable;
 
     /**
-     * @dev Emitted when erc20EnabledLooksRareAggregator is set
-     */
-    event ERC20EnabledLooksRareAggregatorSet();
-
-    /**
      * @dev Emitted when fee is updated
      * @param proxy Proxy to apply the fee to
      * @param bp Fee basis point

--- a/test/foundry/LooksRareAggregator.t.sol
+++ b/test/foundry/LooksRareAggregator.t.sol
@@ -31,8 +31,6 @@ contract LooksRareAggregatorTest is TestParameters, TestHelpers, TokenRescuerTes
 
     function testSetERC20EnabledLooksRareAggregator() public {
         assertEq(address(aggregator.erc20EnabledLooksRareAggregator()), address(0));
-        vm.expectEmit(true, false, false, false);
-        emit ERC20EnabledLooksRareAggregatorSet();
         address erc20EnabledLooksRareAggregator = address(new ERC20EnabledLooksRareAggregator(address(aggregator)));
         aggregator.setERC20EnabledLooksRareAggregator(erc20EnabledLooksRareAggregator);
         assertEq(address(aggregator.erc20EnabledLooksRareAggregator()), erc20EnabledLooksRareAggregator);

--- a/test/foundry/TestParameters.sol
+++ b/test/foundry/TestParameters.sol
@@ -34,7 +34,6 @@ abstract contract TestParameters {
     uint256 internal constant INITIAL_ETH_BALANCE = 400 ether;
     uint256 internal constant INITIAL_USDC_BALANCE = 500000e6;
 
-    event ERC20EnabledLooksRareAggregatorSet();
     event FeeUpdated(address proxy, uint256 bp, address recipient);
     event FunctionAdded(address indexed proxy, bytes4 selector);
     event FunctionRemoved(address indexed proxy, bytes4 selector);


### PR DESCRIPTION
This event is probably not useful at all as it will only be emitted once and ERC20 orders wouldn't be possible if we don't set it anyway (or maybe we should even go with CREATE2 address calculation instead of using a setter function)