### PR TITLE
fix: SeaportProxy does not need to receive ETH

### DIFF
--- a/contracts/LooksRareAggregator.sol
+++ b/contracts/LooksRareAggregator.sol
@@ -217,6 +217,11 @@ contract LooksRareAggregator is
         _executeERC1155SafeBatchTransferFrom(collection, address(this), to, tokenIds, amounts);
     }
 
+    /**
+     * @dev If any order fails, the ETH paid to the marketplace
+     *      is refunded to the aggregator contract. The aggregator then has to refund
+     *      the ETH back to the user through _returnETHIfAny.
+     */
     receive() external payable {}
 
     function _encodeCalldataAndValidateFeeBp(

--- a/contracts/proxies/SeaportProxy.sol
+++ b/contracts/proxies/SeaportProxy.sol
@@ -97,13 +97,6 @@ contract SeaportProxy is IProxy, TokenRescuer {
         }
     }
 
-    /**
-     * @dev If fulfillAvailableAdvancedOrders fails, the ETH paid to Seaport
-     *      is refunded to the proxy contract. The proxy then has to refund
-     *      the ETH back to the user through _returnETHIfAny.
-     */
-    receive() external payable {}
-
     function _executeAtomicOrders(
         BasicOrder[] calldata orders,
         bytes[] calldata ordersExtraData,


### PR DESCRIPTION
Since it is being delegatecall to 