### PR TITLE
test: Expect emit all params set to true

### DIFF
--- a/test/foundry/ConflictedOrders.t.sol
+++ b/test/foundry/ConflictedOrders.t.sol
@@ -49,7 +49,8 @@ contract ConflictedOrdersTest is TestParameters, TestHelpers, SeaportProxyTestHe
     function testExecutePartialSuccess() public asPrankedUser(_buyer) {
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(false);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: tradeData[0].orders[0].price + tradeData[1].orders[0].price}(
             new TokenTransfer[](0),

--- a/test/foundry/CryptoPunksProxy.t.sol
+++ b/test/foundry/CryptoPunksProxy.t.sol
@@ -58,7 +58,8 @@ contract CryptoPunksProxyTest is TestParameters, TestHelpers {
         // Pay nothing for the second order
         tradeData[0].orders[1].price = 0;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         aggregator.execute{value: 68.5 ether}({
@@ -139,7 +140,8 @@ contract CryptoPunksProxyTest is TestParameters, TestHelpers {
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         aggregator.execute{value: 138 ether}({

--- a/test/foundry/LooksRareAggregator.t.sol
+++ b/test/foundry/LooksRareAggregator.t.sol
@@ -51,7 +51,8 @@ contract LooksRareAggregatorTest is TestParameters, TestHelpers {
 
     function testAddFunction() public {
         assertTrue(!aggregator.supportsProxyFunction(address(looksRareProxy), LooksRareProxy.execute.selector));
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit FunctionAdded(address(looksRareProxy), LooksRareProxy.execute.selector);
         aggregator.addFunction(address(looksRareProxy), LooksRareProxy.execute.selector);
         assertTrue(aggregator.supportsProxyFunction(address(looksRareProxy), LooksRareProxy.execute.selector));
@@ -68,7 +69,8 @@ contract LooksRareAggregatorTest is TestParameters, TestHelpers {
         aggregator.addFunction(address(looksRareProxy), LooksRareProxy.execute.selector);
         assertTrue(aggregator.supportsProxyFunction(address(looksRareProxy), LooksRareProxy.execute.selector));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit FunctionRemoved(address(looksRareProxy), LooksRareProxy.execute.selector);
         aggregator.removeFunction(address(looksRareProxy), LooksRareProxy.execute.selector);
         assertTrue(!aggregator.supportsProxyFunction(address(looksRareProxy), LooksRareProxy.execute.selector));

--- a/test/foundry/LooksRareAggregatorTrades.t.sol
+++ b/test/foundry/LooksRareAggregatorTrades.t.sol
@@ -85,7 +85,8 @@ contract LooksRareAggregatorTradesTest is
 
         vm.deal(_buyer, orders[0].price);
         vm.prank(_buyer);
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: orders[0].price}(tokenTransfers, tradeData, address(0), _buyer, false);
 

--- a/test/foundry/LooksRareProxy.t.sol
+++ b/test/foundry/LooksRareProxy.t.sol
@@ -64,7 +64,8 @@ contract LooksRareProxyTest is TestParameters, TestHelpers, LooksRareProxyTestHe
         tradeData[0].orders[0].price -= 0.1 ether;
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, false);
 
@@ -79,7 +80,8 @@ contract LooksRareProxyTest is TestParameters, TestHelpers, LooksRareProxyTestHe
 
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price + 0.1 ether;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, false);
 

--- a/test/foundry/LooksRareV2Proxy.t.sol
+++ b/test/foundry/LooksRareV2Proxy.t.sol
@@ -174,7 +174,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
         vm.prank(NFT_OWNER);
         IERC721(MULTIFAUCET_NFT).transferFrom(NFT_OWNER, address(69), 2828267);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         vm.prank(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, false);
@@ -190,7 +191,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value + 0.1 ether}(tokenTransfers, tradeData, _buyer, _buyer, false);
 
@@ -239,7 +241,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
 
@@ -254,7 +257,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
 
@@ -268,7 +272,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
 
@@ -282,7 +287,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
 
@@ -298,7 +304,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), value);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -315,7 +322,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), value);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -331,7 +339,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), value);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -347,7 +356,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), value);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -361,7 +371,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         uint256 value = _orderValue(tradeData[0], address(0));
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: value}(tokenTransfers, tradeData, _buyer, _buyer, isAtomic);
 
@@ -378,7 +389,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), value);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -398,7 +410,8 @@ contract LooksRareV2ProxyTest is TestParameters, TestHelpers, LooksRareV2ProxyTe
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledLooksRareAggregator), wethValue);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledLooksRareAggregator.execute{value: ethValue}(tokenTransfers, tradeData, _buyer, isAtomic);
 

--- a/test/foundry/MultipleMarkets.t.sol
+++ b/test/foundry/MultipleMarkets.t.sol
@@ -54,7 +54,8 @@ contract MultipleMarketsTest is TestParameters, TestHelpers, SeaportProxyTestHel
         tradeData[1].orders[0].price -= 0.01 ether;
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[1].orders[0].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice}(new TokenTransfer[](0), tradeData, _buyer, _buyer, false);
 
@@ -67,7 +68,8 @@ contract MultipleMarketsTest is TestParameters, TestHelpers, SeaportProxyTestHel
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[1].orders[0].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice}(new TokenTransfer[](0), tradeData, _buyer, _buyer, isAtomic);
 

--- a/test/foundry/SeaportProxyERC1155.t.sol
+++ b/test/foundry/SeaportProxyERC1155.t.sol
@@ -57,7 +57,8 @@ contract SeaportProxyERC1155Test is TestParameters, TestHelpers, SeaportProxyTes
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(false);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         // Not paying for the second order
@@ -70,7 +71,8 @@ contract SeaportProxyERC1155Test is TestParameters, TestHelpers, SeaportProxyTes
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
@@ -83,7 +85,8 @@ contract SeaportProxyERC1155Test is TestParameters, TestHelpers, SeaportProxyTes
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price;

--- a/test/foundry/SeaportProxyERC721.t.sol
+++ b/test/foundry/SeaportProxyERC721.t.sol
@@ -53,7 +53,8 @@ contract SeaportProxyERC721Test is TestParameters, TestHelpers, SeaportProxyTest
     function testExecutePartialSuccess() public asPrankedUser(_buyer) {
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         // Not paying for the second order
         aggregator.execute{value: tradeData[0].orders[0].price}(
@@ -73,7 +74,8 @@ contract SeaportProxyERC721Test is TestParameters, TestHelpers, SeaportProxyTest
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice + 1 ether}(new TokenTransfer[](0), tradeData, _buyer, _buyer, isAtomic);
 

--- a/test/foundry/SeaportProxyMultipleCollectionTypes.t.sol
+++ b/test/foundry/SeaportProxyMultipleCollectionTypes.t.sol
@@ -41,7 +41,8 @@ contract SeaportProxyMultipleCollectionTypesTest is TestParameters, TestHelpers,
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice}(new TokenTransfer[](0), tradeData, _buyer, _buyer, isAtomic);
 

--- a/test/foundry/SeaportProxyMultipleCurrencies.t.sol
+++ b/test/foundry/SeaportProxyMultipleCurrencies.t.sol
@@ -65,7 +65,8 @@ contract SeaportProxyMultipleCurrenciesTest is TestParameters, TestHelpers, Seap
 
         IERC20(USDC).approve(address(erc20EnabledAggregator), usdcAmount);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -92,7 +93,8 @@ contract SeaportProxyMultipleCurrenciesTest is TestParameters, TestHelpers, Seap
 
         IERC20(USDC).approve(address(erc20EnabledAggregator), usdcAmount);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 

--- a/test/foundry/SeaportProxyMultipleCurrenciesRandomOrder.t.sol
+++ b/test/foundry/SeaportProxyMultipleCurrenciesRandomOrder.t.sol
@@ -108,7 +108,8 @@ contract SeaportProxyMultipleCurrenciesRandomOrderTest is TestParameters, TestHe
         tokenTransfers[0].amount = usdcAmount;
         tokenTransfers[0].currency = USDC;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -154,7 +155,8 @@ contract SeaportProxyMultipleCurrenciesRandomOrderTest is TestParameters, TestHe
         tokenTransfers[0].amount = usdcAmount;
         tokenTransfers[0].currency = USDC;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -200,7 +202,8 @@ contract SeaportProxyMultipleCurrenciesRandomOrderTest is TestParameters, TestHe
         tokenTransfers[0].amount = usdcAmount;
         tokenTransfers[0].currency = USDC;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -246,7 +249,8 @@ contract SeaportProxyMultipleCurrenciesRandomOrderTest is TestParameters, TestHe
         tokenTransfers[0].amount = usdcAmount;
         tokenTransfers[0].currency = USDC;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 

--- a/test/foundry/Seaport_V1_4_ProxyERC1155.t.sol
+++ b/test/foundry/Seaport_V1_4_ProxyERC1155.t.sol
@@ -57,7 +57,8 @@ contract Seaport_V1_4_ProxyERC1155Test is TestParameters, TestHelpers, Seaport_V
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(false);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         // Not paying for the second order
@@ -71,7 +72,8 @@ contract Seaport_V1_4_ProxyERC1155Test is TestParameters, TestHelpers, Seaport_V
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
@@ -85,7 +87,8 @@ contract Seaport_V1_4_ProxyERC1155Test is TestParameters, TestHelpers, Seaport_V
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         TokenTransfer[] memory tokenTransfers = new TokenTransfer[](0);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
 
         uint256 value = tradeData[0].orders[0].price + tradeData[0].orders[1].price;

--- a/test/foundry/Seaport_V1_4_ProxyERC721.t.sol
+++ b/test/foundry/Seaport_V1_4_ProxyERC721.t.sol
@@ -53,7 +53,8 @@ contract Seaport_V1_4_ProxyERC721Test is TestParameters, TestHelpers, Seaport_V1
     function testExecutePartialSuccess() public asPrankedUser(_buyer) {
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         // Not paying for the second order
         aggregator.execute{value: tradeData[0].orders[0].price}(
@@ -73,7 +74,8 @@ contract Seaport_V1_4_ProxyERC721Test is TestParameters, TestHelpers, Seaport_V1
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData();
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice + 1 ether}(new TokenTransfer[](0), tradeData, _buyer, _buyer, isAtomic);
 

--- a/test/foundry/Seaport_V1_4_ProxyMultipleCollectionTypes.t.sol
+++ b/test/foundry/Seaport_V1_4_ProxyMultipleCollectionTypes.t.sol
@@ -41,7 +41,8 @@ contract Seaport_V1_4_ProxyMultipleCollectionTypesTest is TestParameters, TestHe
         ILooksRareAggregator.TradeData[] memory tradeData = _generateTradeData(isAtomic);
         uint256 totalPrice = tradeData[0].orders[0].price + tradeData[0].orders[1].price;
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         aggregator.execute{value: totalPrice}(new TokenTransfer[](0), tradeData, _buyer, _buyer, isAtomic);
 

--- a/test/foundry/Seaport_V1_4_ProxyMultipleCurrencies.t.sol
+++ b/test/foundry/Seaport_V1_4_ProxyMultipleCurrencies.t.sol
@@ -65,7 +65,8 @@ contract Seaport_V1_4_ProxyMultipleCurrenciesTest is TestParameters, TestHelpers
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledAggregator), wethAmount);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 
@@ -92,7 +93,8 @@ contract Seaport_V1_4_ProxyMultipleCurrenciesTest is TestParameters, TestHelpers
 
         IERC20(WETH_GOERLI).approve(address(erc20EnabledAggregator), wethAmount);
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false, checkTopic3: false, checkData: true});
+        vm.expectEmit({checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true});
+
         emit Sweep(_buyer);
         erc20EnabledAggregator.execute{value: ethAmount}(tokenTransfers, tradeData, _buyer, isAtomic);
 


### PR DESCRIPTION
https://book.getfoundry.sh/tutorials/best-practices

```
When testing events, prefer setting all expectEmit arguments to true, i.e. vm.expectEmit(true, true, true, true). Benefits:

This ensures you test everything in your event.
If you add a topic (i.e. a new indexed parameter), it's now tested by default.
Even if you only have 1 topic, the extra true arguments don't hurt.
```